### PR TITLE
DAG-725. La til redirect fra soknad-veileder til den nye søknadsdialogen i prod, og reell ingress i dev

### DIFF
--- a/.nais/dev-gcp/ingresses.yaml
+++ b/.nais/dev-gcp/ingresses.yaml
@@ -1,3 +1,3 @@
 ingresses:
   - https://dp-videresending.dev.intern.nav.no
-  - https://arbeid.dev.nav.no/arbeid/dagpenger/soknad-veileder123
+  - https://arbeid.dev.nav.no/arbeid/dagpenger/soknad-veileder

--- a/.nais/dev-gcp/nginx.conf.d/dp-soknadveileder.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-soknadveileder.conf
@@ -2,7 +2,7 @@ server {
   listen       8080;
   server_name  arbeid.dev.nav.no;
 
-  location /arbeid/dagpenger/soknad-veileder123 {
+  location /arbeid/dagpenger/soknad-veileder {
     return 301 $scheme://arbeid.dev.nav.no/dagpenger/dialog/soknad;
   }
 }

--- a/.nais/prod-gcp/ingresses.yaml
+++ b/.nais/prod-gcp/ingresses.yaml
@@ -1,2 +1,3 @@
 ingresses:
   - https://dp-videresending.intern.nav.no
+  - https://www.nav.no/arbeid/dagpenger/soknad-veileder

--- a/.nais/prod-gcp/nginx.conf.d/dp-soknadveileder.conf
+++ b/.nais/prod-gcp/nginx.conf.d/dp-soknadveileder.conf
@@ -1,0 +1,8 @@
+server {
+  listen       8080;
+  server_name  www.nav.no;
+
+  location /arbeid/dagpenger/soknad-veileder {
+    return 301 $scheme://www.nav.no/dagpenger/dialog/soknad;
+  }
+}


### PR DESCRIPTION
NB! Prodsettes ikke før den gamle søknaden skal slås av.

Co-authored-by: André Roaldseth <andre.roaldseth@nav.no>