### PR TITLE
Redirect for innlogget kalkulator

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
 
   deploy-dev:
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/innlogget-kalkulator'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
 
   deploy-dev:
     needs: build
-    if: github.ref == 'refs/heads/innlogget-kalkulator'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.nais/dev-gcp/ingresses.yaml
+++ b/.nais/dev-gcp/ingresses.yaml
@@ -2,3 +2,4 @@ ingresses:
   - https://dp-videresending.dev.intern.nav.no
   - https://arbeid.dev.nav.no/arbeid/dagpenger/soknad-veileder
   - https://arbeid.dev.nav.no/arbeid/dagpenger/soknad-innsending
+  - https://arbeid.dev.nav.no/arbeid/dagpenger/kalkulator

--- a/.nais/dev-gcp/nginx.conf.d/dp-arbeid.dev.nav.no.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-arbeid.dev.nav.no.conf
@@ -3,7 +3,7 @@ server {
   server_name  arbeid.dev.nav.no;
 
   location /arbeid/dagpenger/kalkulator {
-    return 301 "https://arbeid.dev.nav.no/arbeid/arbeidsledig#hvor-mye-kan-du-fa-i-dagpenger";
+    return 301 "https://www.nav.no/arbeid/arbeidsledig#hvor-mye-kan-du-fa-i-dagpenger";
   }
 
   location /arbeid/dagpenger/soknad-innsending {

--- a/.nais/dev-gcp/nginx.conf.d/dp-arbeid.dev.nav.no.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-arbeid.dev.nav.no.conf
@@ -1,0 +1,16 @@
+server {
+  listen       8080;
+  server_name  arbeid.dev.nav.no;
+
+  location /arbeid/dagpenger/kalkulator {
+    return 301 $scheme://arbeid.dev.nav.no/arbeid/arbeidsledig%23hvor-mye-kan-du-fa-i-dagpenger;
+  }
+
+  location /arbeid/dagpenger/soknad-innsending {
+    return 301 $scheme://arbeid.dev.nav.no/dagpenger/dialog/generell-innsending;
+  }
+
+  location /arbeid/dagpenger/soknad-veileder {
+    return 301 $scheme://arbeid.dev.nav.no/dagpenger/dialog/soknad;
+  }
+}

--- a/.nais/dev-gcp/nginx.conf.d/dp-arbeid.dev.nav.no.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-arbeid.dev.nav.no.conf
@@ -3,7 +3,7 @@ server {
   server_name  arbeid.dev.nav.no;
 
   location /arbeid/dagpenger/kalkulator {
-    return 301 "${scheme}://arbeid.dev.nav.no/arbeid/arbeidsledig#hvor-mye-kan-du-fa-i-dagpenger"
+    return 301 "https://arbeid.dev.nav.no/arbeid/arbeidsledig#hvor-mye-kan-du-fa-i-dagpenger"
   }
 
   location /arbeid/dagpenger/soknad-innsending {

--- a/.nais/dev-gcp/nginx.conf.d/dp-arbeid.dev.nav.no.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-arbeid.dev.nav.no.conf
@@ -3,7 +3,7 @@ server {
   server_name  arbeid.dev.nav.no;
 
   location /arbeid/dagpenger/kalkulator {
-    return 301 $scheme://arbeid.dev.nav.no/arbeid/arbeidsledig%23hvor-mye-kan-du-fa-i-dagpenger;
+    return 301 "${scheme}://arbeid.dev.nav.no/arbeid/arbeidsledig#hvor-mye-kan-du-fa-i-dagpenger"
   }
 
   location /arbeid/dagpenger/soknad-innsending {

--- a/.nais/dev-gcp/nginx.conf.d/dp-arbeid.dev.nav.no.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-arbeid.dev.nav.no.conf
@@ -3,7 +3,7 @@ server {
   server_name  arbeid.dev.nav.no;
 
   location /arbeid/dagpenger/kalkulator {
-    return 301 "https://arbeid.dev.nav.no/arbeid/arbeidsledig#hvor-mye-kan-du-fa-i-dagpenger"
+    return 301 "https://arbeid.dev.nav.no/arbeid/arbeidsledig#hvor-mye-kan-du-fa-i-dagpenger";
   }
 
   location /arbeid/dagpenger/soknad-innsending {

--- a/.nais/dev-gcp/nginx.conf.d/dp-kalkulator-frontend.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-kalkulator-frontend.conf
@@ -3,6 +3,6 @@ server {
   server_name  arbeid.dev.nav.no;
 
   location /arbeid/dagpenger/kalkulator {
-    return 301 "${scope}://arbeid.dev.nav.no/arbeid/arbeidsledig#hvor-mye-kan-du-fa-i-dagpenger";
+    return 301 $scheme://arbeid.dev.nav.no/arbeid/arbeidsledig%23hvor-mye-kan-du-fa-i-dagpenger;
   }
 }

--- a/.nais/dev-gcp/nginx.conf.d/dp-kalkulator-frontend.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-kalkulator-frontend.conf
@@ -1,8 +1,0 @@
-server {
-  listen       8080;
-  server_name  arbeid.dev.nav.no;
-
-  location /arbeid/dagpenger/kalkulator {
-    return 301 $scheme://arbeid.dev.nav.no/arbeid/arbeidsledig%23hvor-mye-kan-du-fa-i-dagpenger;
-  }
-}

--- a/.nais/dev-gcp/nginx.conf.d/dp-kalkulator-frontend.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-kalkulator-frontend.conf
@@ -1,0 +1,8 @@
+server {
+  listen       8080;
+  server_name  arbeid.dev.nav.no;
+
+  location /arbeid/dagpenger/kalkulator {
+    return 301 "${scope}://arbeid.dev.nav.no/arbeid/arbeidsledig#hvor-mye-kan-du-fa-i-dagpenger";
+  }
+}

--- a/.nais/dev-gcp/nginx.conf.d/dp-soknad-innsending.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-soknad-innsending.conf
@@ -1,8 +1,0 @@
-server {
-  listen       8080;
-  server_name  arbeid.dev.nav.no;
-
-  location /arbeid/dagpenger/soknad-innsending {
-    return 301 $scheme://arbeid.dev.nav.no/dagpenger/dialog/generell-innsending;
-  }
-}

--- a/.nais/dev-gcp/nginx.conf.d/dp-soknadveileder.conf
+++ b/.nais/dev-gcp/nginx.conf.d/dp-soknadveileder.conf
@@ -1,8 +1,0 @@
-server {
-  listen       8080;
-  server_name  arbeid.dev.nav.no;
-
-  location /arbeid/dagpenger/soknad-veileder {
-    return 301 $scheme://arbeid.dev.nav.no/dagpenger/dialog/soknad;
-  }
-}

--- a/.nais/prod-gcp/nginx.conf.d/dp-soknad-innsending.conf
+++ b/.nais/prod-gcp/nginx.conf.d/dp-soknad-innsending.conf
@@ -1,8 +1,0 @@
-server {
-  listen       8080;
-  server_name  www.nav.no;
-
-  location /arbeid/dagpenger/soknad-innsending {
-    return 301 $scheme://www.nav.no/dagpenger/dialog/generell-innsending;
-  }
-}

--- a/.nais/prod-gcp/nginx.conf.d/dp-videresending.conf
+++ b/.nais/prod-gcp/nginx.conf.d/dp-videresending.conf
@@ -1,8 +1,0 @@
-server {
-  listen       8080;
-  server_name  dp-videresending.intern.nav.no;
-
-  location /test {
-    return 201 "cool";
-  }
-}

--- a/.nais/prod-gcp/nginx.conf.d/dp-www.nav.no.conf
+++ b/.nais/prod-gcp/nginx.conf.d/dp-www.nav.no.conf
@@ -2,11 +2,15 @@ server {
   listen       8080;
   server_name  www.nav.no;
 
-  location /arbeid/dagpenger/soknad-veileder {
-    return 301 $scheme://www.nav.no/dagpenger/dialog/soknad;
+  location /arbeid/dagpenger/kalkulator {
+    return 301 "https://www.nav.no/arbeid/arbeidsledig#hvor-mye-kan-du-fa-i-dagpenger";
   }
 
   location /arbeid/dagpenger/soknad-innsending {
     return 301 $scheme://www.nav.no/dagpenger/dialog/generell-innsending;
+  }
+
+  location /arbeid/dagpenger/soknad-veileder {
+    return 301 $scheme://www.nav.no/dagpenger/dialog/soknad;
   }
 }

--- a/.nais/prod-gcp/nginx.conf.d/dp-www.nav.no.conf
+++ b/.nais/prod-gcp/nginx.conf.d/dp-www.nav.no.conf
@@ -5,4 +5,8 @@ server {
   location /arbeid/dagpenger/soknad-veileder {
     return 301 $scheme://www.nav.no/dagpenger/dialog/soknad;
   }
+
+  location /arbeid/dagpenger/soknad-innsending {
+    return 301 $scheme://www.nav.no/dagpenger/dialog/generell-innsending;
+  }
 }

--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@ Du må både legge til ingresser appen skal håndtere og nginx-config for å hå
 
 ### Eksempel Nginx-config
 
-Regler må gruppes per ingress i en `server` blokk med matchende `server_name`.
+Regler for ingresser på samme server må grupperes i en `server` blokk med matchende `server_name`.
 
 ```nginx configuration
 server {
   listen       8080;
-  server_name  app1.dev.intern.nav.no;
+  server_name  www.nav.no;
 
-  return 301 $scheme://nytt-navn.dev.intern.nav.no$request_uri;
+  location /arbeid/dagpenger/gammel-tjeneste1 {
+    return 301 $scheme://www.nav.no/dagpenger/ny-tjeneste1;
+  }
+
+  location /arbeid/dagpenger/gammel-tjeneste2 {
+    return 301 $scheme://www.nav.no/dagpenger/ny-tjeneste2;
+  }
 }
 ```

--- a/nginx.conf
+++ b/nginx.conf
@@ -33,6 +33,7 @@ http {
   server {
     listen       8080 default_server;
     server_name  localhost;
+    add_header   X-upstream "dp-videresending
 
     location / {
       return 404;

--- a/nginx.conf
+++ b/nginx.conf
@@ -33,7 +33,7 @@ http {
   server {
     listen       8080 default_server;
     server_name  localhost;
-    add_header   X-upstream "dp-videresending
+    add_header   X-upstream "dp-videresending";
 
     location / {
       return 404;

--- a/nginx.conf
+++ b/nginx.conf
@@ -33,7 +33,6 @@ http {
   server {
     listen       8080 default_server;
     server_name  localhost;
-    add_header   X-upstream "dp-videresending";
 
     location / {
       return 404;


### PR DESCRIPTION
Setter opp redirect for innlogget kalkulator. Siden den uinnloggede kun finnes i prod hardkoder vi lenken dit i begge miljøer. 

Vi har også funnet ut at man må gruppere regler med samme server_name i én server-blokk. Hvis ikke vil reglene overskrive hverandre.

Oppdaterer README for å beskrive dette bedre.